### PR TITLE
Support for media keys for play, pause and skipping

### DIFF
--- a/PocketCast.xcodeproj/project.pbxproj
+++ b/PocketCast.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A441E3B01B4FF0BE008DBC37 /* NSObject+SPInvocationGrabbing.m in Sources */ = {isa = PBXBuildFile; fileRef = A441E3AD1B4FF0BE008DBC37 /* NSObject+SPInvocationGrabbing.m */; };
+		A441E3B11B4FF0BE008DBC37 /* SPMediaKeyTap.m in Sources */ = {isa = PBXBuildFile; fileRef = A441E3AF1B4FF0BE008DBC37 /* SPMediaKeyTap.m */; };
 		C80F65D61ADE156C00277D77 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80F65D51ADE156C00277D77 /* AppDelegate.swift */; };
 		C80F65D81ADE156C00277D77 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C80F65D71ADE156C00277D77 /* Images.xcassets */; };
 		C80F65DB1ADE156C00277D77 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = C80F65D91ADE156C00277D77 /* MainMenu.xib */; };
@@ -25,6 +27,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A441E39E1B4FEF9E008DBC37 /* PocketCast-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PocketCast-Bridging-Header.h"; sourceTree = "<group>"; };
+		A441E3AC1B4FF0BE008DBC37 /* NSObject+SPInvocationGrabbing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+SPInvocationGrabbing.h"; sourceTree = "<group>"; };
+		A441E3AD1B4FF0BE008DBC37 /* NSObject+SPInvocationGrabbing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+SPInvocationGrabbing.m"; sourceTree = "<group>"; };
+		A441E3AE1B4FF0BE008DBC37 /* SPMediaKeyTap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPMediaKeyTap.h; sourceTree = "<group>"; };
+		A441E3AF1B4FF0BE008DBC37 /* SPMediaKeyTap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPMediaKeyTap.m; sourceTree = "<group>"; };
 		C80F65D01ADE156C00277D77 /* PocketCast.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PocketCast.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C80F65D41ADE156C00277D77 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C80F65D51ADE156C00277D77 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -35,7 +42,6 @@
 		C80F65E61ADE156C00277D77 /* PocketCastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketCastTests.swift; sourceTree = "<group>"; };
 		C80F65F71ADE2BEE00277D77 /* MyApplication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MyApplication.swift; path = PocketCast/MyApplication.swift; sourceTree = "<group>"; };
 		C80F65FA1ADE319300277D77 /* MyPlayground.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = MyPlayground.playground; sourceTree = "<group>"; };
-		C80F66001ADE367F00277D77 /* PocketCast-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "PocketCast-Bridging-Header.h"; path = "PocketCast/PocketCast-Bridging-Header.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,12 +62,32 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		A441E3AA1B4FF0BE008DBC37 /* SPMediaKeyTap */ = {
+			isa = PBXGroup;
+			children = (
+				A441E3AB1B4FF0BE008DBC37 /* SPInvocationGrabbing */,
+				A441E3AE1B4FF0BE008DBC37 /* SPMediaKeyTap.h */,
+				A441E3AF1B4FF0BE008DBC37 /* SPMediaKeyTap.m */,
+			);
+			name = SPMediaKeyTap;
+			path = PocketCast/SPMediaKeyTap;
+			sourceTree = "<group>";
+		};
+		A441E3AB1B4FF0BE008DBC37 /* SPInvocationGrabbing */ = {
+			isa = PBXGroup;
+			children = (
+				A441E3AC1B4FF0BE008DBC37 /* NSObject+SPInvocationGrabbing.h */,
+				A441E3AD1B4FF0BE008DBC37 /* NSObject+SPInvocationGrabbing.m */,
+			);
+			path = SPInvocationGrabbing;
+			sourceTree = "<group>";
+		};
 		C80F65C71ADE156C00277D77 = {
 			isa = PBXGroup;
 			children = (
-				C80F66001ADE367F00277D77 /* PocketCast-Bridging-Header.h */,
 				C80F65FA1ADE319300277D77 /* MyPlayground.playground */,
 				C80F65F71ADE2BEE00277D77 /* MyApplication.swift */,
+				A441E3AA1B4FF0BE008DBC37 /* SPMediaKeyTap */,
 				C80F65D21ADE156C00277D77 /* PocketCast */,
 				C80F65E31ADE156C00277D77 /* PocketCastTests */,
 				C80F65D11ADE156C00277D77 /* Products */,
@@ -80,6 +106,7 @@
 		C80F65D21ADE156C00277D77 /* PocketCast */ = {
 			isa = PBXGroup;
 			children = (
+				A441E39E1B4FEF9E008DBC37 /* PocketCast-Bridging-Header.h */,
 				C80F65D51ADE156C00277D77 /* AppDelegate.swift */,
 				C80F65D71ADE156C00277D77 /* Images.xcassets */,
 				C80F65D91ADE156C00277D77 /* MainMenu.xib */,
@@ -212,8 +239,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A441E3B01B4FF0BE008DBC37 /* NSObject+SPInvocationGrabbing.m in Sources */,
 				C80F65F81ADE2BEE00277D77 /* MyApplication.swift in Sources */,
 				C80F65D61ADE156C00277D77 /* AppDelegate.swift in Sources */,
+				A441E3B11B4FF0BE008DBC37 /* SPMediaKeyTap.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -409,6 +438,7 @@
 				C80F65EC1ADE156C00277D77 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		C80F65ED1ADE156C00277D77 /* Build configuration list for PBXNativeTarget "PocketCastTests" */ = {
 			isa = XCConfigurationList;
@@ -417,6 +447,7 @@
 				C80F65EF1ADE156C00277D77 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/PocketCast/AppDelegate.swift
+++ b/PocketCast/AppDelegate.swift
@@ -49,13 +49,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if u["action"] == "playPause" {
             println("playpause")
             webView.stringByEvaluatingJavaScriptFromString("angular.element(document).injector().get('mediaPlayer').playPause()")
-
-        }
-        if u["action"] == "skip" {
-        println("skipping")
-        webView.stringByEvaluatingJavaScriptFromString("angular.element(document).injector().get('mediaPlayer').jumpForward()")
         }
 
+        if u["action"] == "skipForward" {
+            println("skipping forward")
+            webView.stringByEvaluatingJavaScriptFromString("angular.element(document).injector().get('mediaPlayer').jumpForward()")
+        }
+
+        if u["action"] == "skipBack" {
+            println("skipping back")
+            webView.stringByEvaluatingJavaScriptFromString("angular.element(document).injector().get('mediaPlayer').jumpBack()")
+        }
     }
 
     override func mediaKeyTap(mediaKeyTap : SPMediaKeyTap?, receivedMediaKeyEvent event : NSEvent) {
@@ -73,9 +77,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
                 case Int(NX_KEYTYPE_FAST):
                     NSNotificationCenter.defaultCenter().postNotificationName(
-                        "pocketEvent", object: NSApp, userInfo:["action":"skip"])
+                        "pocketEvent", object: NSApp, userInfo:["action":"skipForward"])
 
-                //case Int32(NX_KEYTYPE_REWIND):
+                case Int(NX_KEYTYPE_REWIND):
+                    NSNotificationCenter.defaultCenter().postNotificationName(
+                        "pocketEvent", object: NSApp, userInfo:["action":"skipBack"])
 
                 default:
                     break;

--- a/PocketCast/AppDelegate.swift
+++ b/PocketCast/AppDelegate.swift
@@ -16,34 +16,71 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBOutlet weak var webView: WebView!
     @IBOutlet weak var window: NSWindow!
 
+    var mediaKeyTap: SPMediaKeyTap?
+
+    override init() {
+        // Register defaults for the whitelist of apps that want to use media keys
+        NSUserDefaults.standardUserDefaults().registerDefaults(
+            [kMediaKeyUsingBundleIdentifiersDefaultsKey : SPMediaKeyTap.defaultMediaKeyUserBundleIdentifiers()])
+    }
 
     func applicationDidFinishLaunching(aNotification: NSNotification) {
         // Insert code here to initialize your application
-        
+
         window.movableByWindowBackground = true
         //window.delegate = self
         window.titleVisibility = NSWindowTitleVisibility.Hidden
         window.titlebarAppearsTransparent = true;
         window.styleMask |= NSFullSizeContentViewWindowMask;
-        
+
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "gotNotification:", name: "pocketEvent", object: nil)
-        
+
         webView.mainFrameURL = "https://play.pocketcasts.com/"
+
+        mediaKeyTap = SPMediaKeyTap(delegate: self)
+        if (SPMediaKeyTap.usesGlobalMediaKeyTap()) {
+            mediaKeyTap!.startWatchingMediaKeys()
+        }
     }
-    
+
     func gotNotification(notification : NSNotification){
         let u = notification.userInfo as! Dictionary<String,String>
-        
+
         if u["action"] == "playPause" {
             println("playpause")
             webView.stringByEvaluatingJavaScriptFromString("angular.element(document).injector().get('mediaPlayer').playPause()")
-            
+
         }
         if u["action"] == "skip" {
         println("skipping")
         webView.stringByEvaluatingJavaScriptFromString("angular.element(document).injector().get('mediaPlayer').jumpForward()")
         }
 
+    }
+
+    override func mediaKeyTap(mediaKeyTap : SPMediaKeyTap?, receivedMediaKeyEvent event : NSEvent) {
+
+        let keyCode = Int((event.data1 & 0xFFFF0000) >> 16);
+        let keyFlags = (event.data1 & 0x0000FFFF);
+        let keyIsPressed = (((keyFlags & 0xFF00) >> 8)) == 0xA;
+        let keyRepeat = (keyFlags & 0x1);
+
+        if (keyIsPressed) {
+            switch (keyCode) {
+                case Int(NX_KEYTYPE_PLAY):
+                    NSNotificationCenter.defaultCenter().postNotificationName(
+                        "pocketEvent", object:NSApp, userInfo:["action":"playPause"])
+
+                case Int(NX_KEYTYPE_FAST):
+                    NSNotificationCenter.defaultCenter().postNotificationName(
+                        "pocketEvent", object: NSApp, userInfo:["action":"skip"])
+
+                //case Int32(NX_KEYTYPE_REWIND):
+
+                default:
+                    break;
+            }
+        }
     }
 
     func applicationWillTerminate(aNotification: NSNotification) {

--- a/PocketCast/MyApplication.swift
+++ b/PocketCast/MyApplication.swift
@@ -10,7 +10,7 @@ import Cocoa
 
 @objc(MyApplication)
 class MyApplication: NSApplication {
-    
+
     override init() {
         println("overriden, boom")
         super.init()
@@ -18,35 +18,27 @@ class MyApplication: NSApplication {
 
     override func sendEvent(theEvent: NSEvent) {
         var overridden=false
-        
-        if (theEvent.type == NSEventType.SystemDefined) {
-            
-            if theEvent.subtype.rawValue == 8 {
-                
-                switch theEvent.data1 {
-                case 1379072:
-                    NSNotificationCenter.defaultCenter().postNotificationName("pocketEvent", object: self, userInfo:["action":"skip"])
-                    overridden = true
-                    
-                case 1444608:
-                    NSNotificationCenter.defaultCenter().postNotificationName("pocketEvent", object: self, userInfo:["action":"playPause"])
-                    overridden = true
-                default:
-                    println("Something else")
+
+        var asd:NSEventSubtype;
+
+        let shouldHandleMediaKeyLocally = !SPMediaKeyTap.usesGlobalMediaKeyTap()
+
+        if (shouldHandleMediaKeyLocally
+            && theEvent.type == NSEventType.SystemDefined
+            && Int32(theEvent.subtype.rawValue) == SPSystemDefinedEventMediaKeys) {
+                if let delegate = self.delegate as? AppDelegate {
+                    delegate.mediaKeyTap(nil, receivedMediaKeyEvent: theEvent)
                 }
-            }
-            
+
         }
 
-        if !overridden {
-            super.sendEvent(theEvent)
-            }
+        super.sendEvent(theEvent)
     }
-    
-    
+
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    
+
+
 }

--- a/PocketCast/PocketCast-Bridging-Header.h
+++ b/PocketCast/PocketCast-Bridging-Header.h
@@ -6,4 +6,5 @@
 //  Copyright (c) 2015 Morten Just Petersen. All rights reserved.
 //
 
-//#include "SPMediaKeyTap.h"
+#import "SPMediaKeyTap/SPMediaKeyTap.h"
+

--- a/PocketCast/SPMediaKeyTap/SPInvocationGrabbing/NSObject+SPInvocationGrabbing.h
+++ b/PocketCast/SPMediaKeyTap/SPInvocationGrabbing/NSObject+SPInvocationGrabbing.h
@@ -1,0 +1,30 @@
+#import <Foundation/Foundation.h>
+
+@interface SPInvocationGrabber : NSObject {
+    id _object;
+    NSInvocation *_invocation;
+    int frameCount;
+    char **frameStrings;
+    BOOL backgroundAfterForward;
+    BOOL onMainAfterForward;
+    BOOL waitUntilDone;
+}
+-(id)initWithObject:(id)obj;
+-(id)initWithObject:(id)obj stacktraceSaving:(BOOL)saveStack;
+@property (readonly, retain, nonatomic) id object;
+@property (readonly, retain, nonatomic) NSInvocation *invocation;
+@property BOOL backgroundAfterForward;
+@property BOOL onMainAfterForward;
+@property BOOL waitUntilDone;
+-(void)invoke; // will release object and invocation
+-(void)printBacktrace;
+-(void)saveBacktrace;
+@end
+
+@interface NSObject (SPInvocationGrabbing)
+-(id)grab;
+-(id)invokeAfter:(NSTimeInterval)delta;
+-(id)nextRunloop;
+-(id)inBackground;
+-(id)onMainAsync:(BOOL)async;
+@end

--- a/PocketCast/SPMediaKeyTap/SPInvocationGrabbing/NSObject+SPInvocationGrabbing.m
+++ b/PocketCast/SPMediaKeyTap/SPInvocationGrabbing/NSObject+SPInvocationGrabbing.m
@@ -1,0 +1,127 @@
+#import "NSObject+SPInvocationGrabbing.h"
+#import <execinfo.h>
+
+#pragma mark Invocation grabbing
+@interface SPInvocationGrabber ()
+@property (readwrite, retain, nonatomic) id object;
+@property (readwrite, retain, nonatomic) NSInvocation *invocation;
+
+@end
+
+@implementation SPInvocationGrabber
+- (id)initWithObject:(id)obj;
+{
+	return [self initWithObject:obj stacktraceSaving:YES];
+}
+
+-(id)initWithObject:(id)obj stacktraceSaving:(BOOL)saveStack;
+{
+	self.object = obj;
+
+	if(saveStack)
+		[self saveBacktrace];
+
+	return self;
+}
+-(void)dealloc;
+{
+	free(frameStrings);
+	self.object = nil;
+	self.invocation = nil;
+	[super dealloc];
+}
+@synthesize invocation = _invocation, object = _object;
+
+@synthesize backgroundAfterForward, onMainAfterForward, waitUntilDone;
+- (void)runInBackground;
+{
+	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+	@try {
+		[self invoke];
+	}
+	@finally {
+		[pool drain];
+	}
+}
+
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation {
+	[anInvocation retainArguments];
+	anInvocation.target = _object;
+	self.invocation = anInvocation;
+	
+	if(backgroundAfterForward)
+		[NSThread detachNewThreadSelector:@selector(runInBackground) toTarget:self withObject:nil];
+	else if(onMainAfterForward)
+        [self performSelectorOnMainThread:@selector(invoke) withObject:nil waitUntilDone:waitUntilDone];
+}
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)inSelector {
+	NSMethodSignature *signature = [super methodSignatureForSelector:inSelector];
+	if (signature == NULL)
+		signature = [_object methodSignatureForSelector:inSelector];
+    
+	return signature;
+}
+
+- (void)invoke;
+{
+
+	@try {
+		[_invocation invoke];
+	}
+	@catch (NSException * e) {
+		NSLog(@"SPInvocationGrabber's target raised %@:\n\t%@\nInvocation was originally scheduled at:", e.name, e);
+		[self printBacktrace];
+		printf("\n");
+		[e raise];
+	}
+
+	self.invocation = nil;
+	self.object = nil;
+}
+
+-(void)saveBacktrace;
+{
+  void *backtraceFrames[128];
+  frameCount = backtrace(&backtraceFrames[0], 128);
+  frameStrings = backtrace_symbols(&backtraceFrames[0], frameCount);
+}
+-(void)printBacktrace;
+{
+	for(int x = 3; x < frameCount; x++) {
+		if(frameStrings[x] == NULL) { break; }
+		printf("%s\n", frameStrings[x]);
+	}
+}
+@end
+
+@implementation NSObject (SPInvocationGrabbing)
+-(id)grab;
+{
+	return [[[SPInvocationGrabber alloc] initWithObject:self] autorelease];
+}
+-(id)invokeAfter:(NSTimeInterval)delta;
+{
+	id grabber = [self grab];
+	[NSTimer scheduledTimerWithTimeInterval:delta target:grabber selector:@selector(invoke) userInfo:nil repeats:NO];
+	return grabber;
+}
+- (id)nextRunloop;
+{
+	return [self invokeAfter:0];
+}
+-(id)inBackground;
+{
+    SPInvocationGrabber *grabber = [self grab];
+	grabber.backgroundAfterForward = YES;
+	return grabber;
+}
+-(id)onMainAsync:(BOOL)async;
+{
+    SPInvocationGrabber *grabber = [self grab];
+	grabber.onMainAfterForward = YES;
+    grabber.waitUntilDone = !async;
+	return grabber;
+}
+
+@end

--- a/PocketCast/SPMediaKeyTap/SPInvocationGrabbing/NSObject+SPInvocationGrabbing.m
+++ b/PocketCast/SPMediaKeyTap/SPInvocationGrabbing/NSObject+SPInvocationGrabbing.m
@@ -28,20 +28,13 @@
 	free(frameStrings);
 	self.object = nil;
 	self.invocation = nil;
-	[super dealloc];
 }
 @synthesize invocation = _invocation, object = _object;
 
 @synthesize backgroundAfterForward, onMainAfterForward, waitUntilDone;
 - (void)runInBackground;
 {
-	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-	@try {
-		[self invoke];
-	}
-	@finally {
-		[pool drain];
-	}
+    [self invoke];
 }
 
 
@@ -98,7 +91,7 @@
 @implementation NSObject (SPInvocationGrabbing)
 -(id)grab;
 {
-	return [[[SPInvocationGrabber alloc] initWithObject:self] autorelease];
+	return [[SPInvocationGrabber alloc] initWithObject:self];
 }
 -(id)invokeAfter:(NSTimeInterval)delta;
 {

--- a/PocketCast/SPMediaKeyTap/SPMediaKeyTap.h
+++ b/PocketCast/SPMediaKeyTap/SPMediaKeyTap.h
@@ -1,0 +1,43 @@
+#include <Cocoa/Cocoa.h>
+#import <IOKit/hidsystem/ev_keymap.h>
+#import <Carbon/Carbon.h>
+
+// http://overooped.com/post/2593597587/mediakeys
+
+#define SPSystemDefinedEventMediaKeys 8
+
+@interface SPMediaKeyTap : NSObject {
+	EventHandlerRef _app_switching_ref;
+	EventHandlerRef _app_terminating_ref;
+	CFMachPortRef _eventPort;
+	CFRunLoopSourceRef _eventPortSource;
+	CFRunLoopRef _tapThreadRL;
+	BOOL _shouldInterceptMediaKeyEvents;
+	id _delegate;
+	// The app that is frontmost in this list owns media keys
+	NSMutableArray *_mediaKeyAppList;
+}
++ (NSArray*)defaultMediaKeyUserBundleIdentifiers;
+
+-(id)initWithDelegate:(id)delegate;
+
++(BOOL)usesGlobalMediaKeyTap;
+-(void)startWatchingMediaKeys;
+-(void)stopWatchingMediaKeys;
+-(void)handleAndReleaseMediaKeyEvent:(NSEvent *)event;
+@end
+
+@interface NSObject (SPMediaKeyTapDelegate)
+-(void)mediaKeyTap:(SPMediaKeyTap*)keyTap receivedMediaKeyEvent:(NSEvent*)event;
+@end
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern NSString *kMediaKeyUsingBundleIdentifiersDefaultsKey;
+extern NSString *kIgnoreMediaKeysDefaultsKey;
+
+#ifdef __cplusplus
+}
+#endif

--- a/PocketCast/SPMediaKeyTap/SPMediaKeyTap.m
+++ b/PocketCast/SPMediaKeyTap/SPMediaKeyTap.m
@@ -1,0 +1,346 @@
+// Copyright (c) 2010 Spotify AB
+#import "SPMediaKeyTap.h"
+#import "SPInvocationGrabbing/NSObject+SPInvocationGrabbing.h" // https://gist.github.com/511181, in submodule
+
+@interface SPMediaKeyTap ()
+-(BOOL)shouldInterceptMediaKeyEvents;
+-(void)setShouldInterceptMediaKeyEvents:(BOOL)newSetting;
+-(void)startWatchingAppSwitching;
+-(void)stopWatchingAppSwitching;
+-(void)eventTapThread;
+@end
+static SPMediaKeyTap *singleton = nil;
+
+static pascal OSStatus appSwitched (EventHandlerCallRef nextHandler, EventRef evt, void* userData);
+static pascal OSStatus appTerminated (EventHandlerCallRef nextHandler, EventRef evt, void* userData);
+static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef event, void *refcon);
+
+
+// Inspired by http://gist.github.com/546311
+
+@implementation SPMediaKeyTap
+
+#pragma mark -
+#pragma mark Setup and teardown
+-(id)initWithDelegate:(id)delegate;
+{
+	_delegate = delegate;
+	[self startWatchingAppSwitching];
+	singleton = self;
+	_mediaKeyAppList = [NSMutableArray new];
+    _tapThreadRL=nil;
+    _eventPort=nil;
+    _eventPortSource=nil;
+	return self;
+}
+-(void)dealloc;
+{
+	[self stopWatchingMediaKeys];
+	[self stopWatchingAppSwitching];
+	[_mediaKeyAppList release];
+	[super dealloc];
+}
+
+-(void)startWatchingAppSwitching;
+{
+	// Listen to "app switched" event, so that we don't intercept media keys if we
+	// weren't the last "media key listening" app to be active
+	EventTypeSpec eventType = { kEventClassApplication, kEventAppFrontSwitched };
+    OSStatus err = InstallApplicationEventHandler(NewEventHandlerUPP(appSwitched), 1, &eventType, self, &_app_switching_ref);
+	assert(err == noErr);
+	
+	eventType.eventKind = kEventAppTerminated;
+    err = InstallApplicationEventHandler(NewEventHandlerUPP(appTerminated), 1, &eventType, self, &_app_terminating_ref);
+	assert(err == noErr);
+}
+-(void)stopWatchingAppSwitching;
+{
+	if(!_app_switching_ref) return;
+	RemoveEventHandler(_app_switching_ref);
+	_app_switching_ref = NULL;
+}
+
+-(void)startWatchingMediaKeys;{
+    // Prevent having multiple mediaKeys threads
+    [self stopWatchingMediaKeys];
+    
+	[self setShouldInterceptMediaKeyEvents:YES];
+	
+	// Add an event tap to intercept the system defined media key events
+	_eventPort = CGEventTapCreate(kCGSessionEventTap,
+								  kCGHeadInsertEventTap,
+								  kCGEventTapOptionDefault,
+								  CGEventMaskBit(NX_SYSDEFINED),
+								  tapEventCallback,
+								  self);
+	assert(_eventPort != NULL);
+	
+    _eventPortSource = CFMachPortCreateRunLoopSource(kCFAllocatorSystemDefault, _eventPort, 0);
+	assert(_eventPortSource != NULL);
+	
+	// Let's do this in a separate thread so that a slow app doesn't lag the event tap
+	[NSThread detachNewThreadSelector:@selector(eventTapThread) toTarget:self withObject:nil];
+}
+-(void)stopWatchingMediaKeys;
+{
+	// TODO<nevyn>: Shut down thread, remove event tap port and source
+    
+    if(_tapThreadRL){
+        CFRunLoopStop(_tapThreadRL);
+        _tapThreadRL=nil;
+    }
+    
+    if(_eventPort){
+        CFMachPortInvalidate(_eventPort);
+        CFRelease(_eventPort);
+        _eventPort=nil;
+    }
+    
+    if(_eventPortSource){
+        CFRelease(_eventPortSource);
+        _eventPortSource=nil;
+    }
+}
+
+#pragma mark -
+#pragma mark Accessors
+
++(BOOL)usesGlobalMediaKeyTap
+{
+#ifdef _DEBUG
+	// breaking in gdb with a key tap inserted sometimes locks up all mouse and keyboard input forever, forcing reboot
+	return NO;
+#else
+	// XXX(nevyn): MediaKey event tap doesn't work on 10.4, feel free to figure out why if you have the energy.
+	return 
+		![[NSUserDefaults standardUserDefaults] boolForKey:kIgnoreMediaKeysDefaultsKey]
+		&& floor(NSAppKitVersionNumber) >= 949/*NSAppKitVersionNumber10_5*/;
+#endif
+}
+
++ (NSArray*)defaultMediaKeyUserBundleIdentifiers;
+{
+	return [NSArray arrayWithObjects:
+		[[NSBundle mainBundle] bundleIdentifier], // your app
+		@"com.spotify.client",
+		@"com.apple.iTunes",
+		@"com.apple.QuickTimePlayerX",
+		@"com.apple.quicktimeplayer",
+		@"com.apple.iWork.Keynote",
+		@"com.apple.iPhoto",
+		@"org.videolan.vlc",
+		@"com.apple.Aperture",
+		@"com.plexsquared.Plex",
+		@"com.soundcloud.desktop",
+		@"org.niltsh.MPlayerX",
+		@"com.ilabs.PandorasHelper",
+		@"com.mahasoftware.pandabar",
+		@"com.bitcartel.pandorajam",
+		@"org.clementine-player.clementine",
+		@"fm.last.Last.fm",
+		@"fm.last.Scrobbler",
+		@"com.beatport.BeatportPro",
+		@"com.Timenut.SongKey",
+		@"com.macromedia.fireworks", // the tap messes up their mouse input
+		@"at.justp.Theremin",
+		@"ru.ya.themblsha.YandexMusic",
+		@"com.jriver.MediaCenter18",
+		@"com.jriver.MediaCenter19",
+		@"com.jriver.MediaCenter20",
+		@"co.rackit.mate",
+		@"com.ttitt.b-music",
+		@"com.beardedspice.BeardedSpice",
+		@"com.plug.Plug",
+		@"com.plug.Plug2",
+    @"com.netease.163music",
+		nil
+	];
+}
+
+
+-(BOOL)shouldInterceptMediaKeyEvents;
+{
+	BOOL shouldIntercept = NO;
+	@synchronized(self) {
+		shouldIntercept = _shouldInterceptMediaKeyEvents;
+	}
+	return shouldIntercept;
+}
+
+-(void)pauseTapOnTapThread:(BOOL)yeahno;
+{
+	CGEventTapEnable(self->_eventPort, yeahno);
+}
+-(void)setShouldInterceptMediaKeyEvents:(BOOL)newSetting;
+{
+	BOOL oldSetting;
+	@synchronized(self) {
+		oldSetting = _shouldInterceptMediaKeyEvents;
+		_shouldInterceptMediaKeyEvents = newSetting;
+	}
+	if(_tapThreadRL && oldSetting != newSetting) {
+		id grab = [self grab];
+		[grab pauseTapOnTapThread:newSetting];
+		NSTimer *timer = [NSTimer timerWithTimeInterval:0 invocation:[grab invocation] repeats:NO];
+		CFRunLoopAddTimer(_tapThreadRL, (CFRunLoopTimerRef)timer, kCFRunLoopCommonModes);
+	}
+}
+
+#pragma mark 
+#pragma mark -
+#pragma mark Event tap callbacks
+
+// Note: method called on background thread
+
+static CGEventRef tapEventCallback2(CGEventTapProxy proxy, CGEventType type, CGEventRef event, void *refcon)
+{
+	SPMediaKeyTap *self = refcon;
+
+    if(type == kCGEventTapDisabledByTimeout) {
+		NSLog(@"Media key event tap was disabled by timeout");
+		CGEventTapEnable(self->_eventPort, TRUE);
+		return event;
+	} else if(type == kCGEventTapDisabledByUserInput) {
+		// Was disabled manually by -[pauseTapOnTapThread]
+		return event;
+	}
+	NSEvent *nsEvent = nil;
+	@try {
+		nsEvent = [NSEvent eventWithCGEvent:event];
+	}
+	@catch (NSException * e) {
+		NSLog(@"Strange CGEventType: %d: %@", type, e);
+		assert(0);
+		return event;
+	}
+
+	if (type != NX_SYSDEFINED || [nsEvent subtype] != SPSystemDefinedEventMediaKeys)
+		return event;
+
+	int keyCode = (([nsEvent data1] & 0xFFFF0000) >> 16);
+    if (keyCode != NX_KEYTYPE_PLAY && keyCode != NX_KEYTYPE_FAST && keyCode != NX_KEYTYPE_REWIND && keyCode != NX_KEYTYPE_PREVIOUS && keyCode != NX_KEYTYPE_NEXT)
+		return event;
+
+	if (![self shouldInterceptMediaKeyEvents])
+		return event;
+	
+	[nsEvent retain]; // matched in handleAndReleaseMediaKeyEvent:
+	[self performSelectorOnMainThread:@selector(handleAndReleaseMediaKeyEvent:) withObject:nsEvent waitUntilDone:NO];
+	
+	return NULL;
+}
+
+static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef event, void *refcon)
+{
+	NSAutoreleasePool *pool = [NSAutoreleasePool new];
+	CGEventRef ret = tapEventCallback2(proxy, type, event, refcon);
+	[pool drain];
+	return ret;
+}
+
+
+// event will have been retained in the other thread
+-(void)handleAndReleaseMediaKeyEvent:(NSEvent *)event {
+	[event autorelease];
+	
+	[_delegate mediaKeyTap:self receivedMediaKeyEvent:event];
+}
+
+
+-(void)eventTapThread;
+{
+	_tapThreadRL = CFRunLoopGetCurrent();
+	CFRunLoopAddSource(_tapThreadRL, _eventPortSource, kCFRunLoopCommonModes);
+	CFRunLoopRun();
+}
+
+#pragma mark Task switching callbacks
+
+NSString *kMediaKeyUsingBundleIdentifiersDefaultsKey = @"SPApplicationsNeedingMediaKeys";
+NSString *kIgnoreMediaKeysDefaultsKey = @"SPIgnoreMediaKeys";
+
+
+
+-(void)mediaKeyAppListChanged;
+{
+	if([_mediaKeyAppList count] == 0) return;
+	
+	/*NSLog(@"--");
+	int i = 0;
+	for (NSValue *psnv in _mediaKeyAppList) {
+		ProcessSerialNumber psn; [psnv getValue:&psn];
+		NSDictionary *processInfo = [(id)ProcessInformationCopyDictionary(
+			&psn,
+			kProcessDictionaryIncludeAllInformationMask
+		) autorelease];
+		NSString *bundleIdentifier = [processInfo objectForKey:(id)kCFBundleIdentifierKey];
+		NSLog(@"%d: %@", i++, bundleIdentifier);
+	}*/
+	
+    ProcessSerialNumber mySerial, topSerial;
+	GetCurrentProcess(&mySerial);
+	[[_mediaKeyAppList objectAtIndex:0] getValue:&topSerial];
+
+	Boolean same;
+	OSErr err = SameProcess(&mySerial, &topSerial, &same);
+	[self setShouldInterceptMediaKeyEvents:(err == noErr && same)];	
+
+}
+-(void)appIsNowFrontmost:(ProcessSerialNumber)psn;
+{
+	NSValue *psnv = [NSValue valueWithBytes:&psn objCType:@encode(ProcessSerialNumber)];
+	
+	NSDictionary *processInfo = [(id)ProcessInformationCopyDictionary(
+		&psn,
+		kProcessDictionaryIncludeAllInformationMask
+	) autorelease];
+	NSString *bundleIdentifier = [processInfo objectForKey:(id)kCFBundleIdentifierKey];
+
+	NSArray *whitelistIdentifiers = [[NSUserDefaults standardUserDefaults] arrayForKey:kMediaKeyUsingBundleIdentifiersDefaultsKey];
+	if(![whitelistIdentifiers containsObject:bundleIdentifier]) return;
+
+	[_mediaKeyAppList removeObject:psnv];
+	[_mediaKeyAppList insertObject:psnv atIndex:0];
+	[self mediaKeyAppListChanged];
+}
+-(void)appTerminated:(ProcessSerialNumber)psn;
+{
+	NSValue *psnv = [NSValue valueWithBytes:&psn objCType:@encode(ProcessSerialNumber)];
+	[_mediaKeyAppList removeObject:psnv];
+	[self mediaKeyAppListChanged];
+}
+
+static pascal OSStatus appSwitched (EventHandlerCallRef nextHandler, EventRef evt, void* userData)
+{
+	SPMediaKeyTap *self = (id)userData;
+
+    ProcessSerialNumber newSerial;
+    GetFrontProcess(&newSerial);
+	
+	[self appIsNowFrontmost:newSerial];
+		
+    return CallNextEventHandler(nextHandler, evt);
+}
+
+static pascal OSStatus appTerminated (EventHandlerCallRef nextHandler, EventRef evt, void* userData)
+{
+	SPMediaKeyTap *self = (id)userData;
+	
+	ProcessSerialNumber deadPSN;
+
+	GetEventParameter(
+		evt, 
+		kEventParamProcessID, 
+		typeProcessSerialNumber, 
+		NULL, 
+		sizeof(deadPSN), 
+		NULL, 
+		&deadPSN
+	);
+
+	
+	[self appTerminated:deadPSN];
+    return CallNextEventHandler(nextHandler, evt);
+}
+
+@end

--- a/PocketCast/SPMediaKeyTap/SPMediaKeyTap.m
+++ b/PocketCast/SPMediaKeyTap/SPMediaKeyTap.m
@@ -37,8 +37,6 @@ static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEv
 {
 	[self stopWatchingMediaKeys];
 	[self stopWatchingAppSwitching];
-	[_mediaKeyAppList release];
-	[super dealloc];
 }
 
 -(void)startWatchingAppSwitching;
@@ -46,11 +44,11 @@ static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEv
 	// Listen to "app switched" event, so that we don't intercept media keys if we
 	// weren't the last "media key listening" app to be active
 	EventTypeSpec eventType = { kEventClassApplication, kEventAppFrontSwitched };
-    OSStatus err = InstallApplicationEventHandler(NewEventHandlerUPP(appSwitched), 1, &eventType, self, &_app_switching_ref);
+    OSStatus err = InstallApplicationEventHandler(NewEventHandlerUPP(appSwitched), 1, &eventType, (__bridge void*)self, &_app_switching_ref);
 	assert(err == noErr);
 	
 	eventType.eventKind = kEventAppTerminated;
-    err = InstallApplicationEventHandler(NewEventHandlerUPP(appTerminated), 1, &eventType, self, &_app_terminating_ref);
+    err = InstallApplicationEventHandler(NewEventHandlerUPP(appTerminated), 1, &eventType, (__bridge void*)self, &_app_terminating_ref);
 	assert(err == noErr);
 }
 -(void)stopWatchingAppSwitching;
@@ -72,7 +70,7 @@ static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEv
 								  kCGEventTapOptionDefault,
 								  CGEventMaskBit(NX_SYSDEFINED),
 								  tapEventCallback,
-								  self);
+								  (__bridge void *)(self));
 	assert(_eventPort != NULL);
 	
     _eventPortSource = CFMachPortCreateRunLoopSource(kCFAllocatorSystemDefault, _eventPort, 0);
@@ -194,7 +192,7 @@ static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEv
 
 static CGEventRef tapEventCallback2(CGEventTapProxy proxy, CGEventType type, CGEventRef event, void *refcon)
 {
-	SPMediaKeyTap *self = refcon;
+	SPMediaKeyTap *self = (__bridge SPMediaKeyTap *)(refcon);
 
     if(type == kCGEventTapDisabledByTimeout) {
 		NSLog(@"Media key event tap was disabled by timeout");
@@ -224,7 +222,7 @@ static CGEventRef tapEventCallback2(CGEventTapProxy proxy, CGEventType type, CGE
 	if (![self shouldInterceptMediaKeyEvents])
 		return event;
 	
-	[nsEvent retain]; // matched in handleAndReleaseMediaKeyEvent:
+	//[nsEvent retain]; // matched in handleAndReleaseMediaKeyEvent:
 	[self performSelectorOnMainThread:@selector(handleAndReleaseMediaKeyEvent:) withObject:nsEvent waitUntilDone:NO];
 	
 	return NULL;
@@ -232,16 +230,16 @@ static CGEventRef tapEventCallback2(CGEventTapProxy proxy, CGEventType type, CGE
 
 static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef event, void *refcon)
 {
-	NSAutoreleasePool *pool = [NSAutoreleasePool new];
+	//NSAutoreleasePool *pool = [NSAutoreleasePool new];
 	CGEventRef ret = tapEventCallback2(proxy, type, event, refcon);
-	[pool drain];
+	//[pool drain];
 	return ret;
 }
 
 
 // event will have been retained in the other thread
 -(void)handleAndReleaseMediaKeyEvent:(NSEvent *)event {
-	[event autorelease];
+	//[event autorelease];
 	
 	[_delegate mediaKeyTap:self receivedMediaKeyEvent:event];
 }
@@ -290,10 +288,10 @@ NSString *kIgnoreMediaKeysDefaultsKey = @"SPIgnoreMediaKeys";
 {
 	NSValue *psnv = [NSValue valueWithBytes:&psn objCType:@encode(ProcessSerialNumber)];
 	
-	NSDictionary *processInfo = [(id)ProcessInformationCopyDictionary(
+	NSDictionary *processInfo = (__bridge id)ProcessInformationCopyDictionary(
 		&psn,
 		kProcessDictionaryIncludeAllInformationMask
-	) autorelease];
+	);
 	NSString *bundleIdentifier = [processInfo objectForKey:(id)kCFBundleIdentifierKey];
 
 	NSArray *whitelistIdentifiers = [[NSUserDefaults standardUserDefaults] arrayForKey:kMediaKeyUsingBundleIdentifiersDefaultsKey];
@@ -312,7 +310,7 @@ NSString *kIgnoreMediaKeysDefaultsKey = @"SPIgnoreMediaKeys";
 
 static pascal OSStatus appSwitched (EventHandlerCallRef nextHandler, EventRef evt, void* userData)
 {
-	SPMediaKeyTap *self = (id)userData;
+	SPMediaKeyTap *self = (__bridge id)userData;
 
     ProcessSerialNumber newSerial;
     GetFrontProcess(&newSerial);
@@ -324,7 +322,7 @@ static pascal OSStatus appSwitched (EventHandlerCallRef nextHandler, EventRef ev
 
 static pascal OSStatus appTerminated (EventHandlerCallRef nextHandler, EventRef evt, void* userData)
 {
-	SPMediaKeyTap *self = (id)userData;
+	SPMediaKeyTap *self = (__bridge id)userData;
 	
 	ProcessSerialNumber deadPSN;
 


### PR DESCRIPTION
Implemented SPMediaKeyTap so that the media keys on the mac keyboards can be used to control Pocket Casts playback. Had to tweak the SPMediaKeyTap a bit to support ARC. I basically just copied the sample code from SPMediaKeyTap repository.

Holding rewind and fast-forward buttons just repeatedly skip. I don't know if implementing rewind and fast-forward is possible.

Fixes #1.
