### PR TITLE
Disable App Transport Security

### DIFF
--- a/PocketCast/Info.plist
+++ b/PocketCast/Info.plist
@@ -30,5 +30,18 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>MyApplication</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>play.pocketcasts.com</key>
+			<dict>
+				<key>NSExceptionsAllowsInsecureHTTPLoads</key>
+				<false/>
+			</dict>
+		</dict>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #7.

OS X El Capitan introduced App Transport Security, which basically prevents regular HTTP connections. Pocket Casts web player downloads the podcasts from their original servers, many of which do not use HTTPS. Therefore playing podcasts is broken.

This patch simply disables ATS for all domains except play.pocketcasts.com.
